### PR TITLE
Correção na configuração do jogo do Capítulo 4

### DIFF
--- a/chapter-4.md
+++ b/chapter-4.md
@@ -99,7 +99,7 @@ function principal () {
         }
     }
 
-    var game = Phaser.Game(conf)
+    var game = new Phaser.Game(conf)
 }
 ```
 {% endcode-tabs-item %}


### PR DESCRIPTION
Como Phaser.Game é um construtor e estava sendo chamado sem `new`, o exemplo não funcionava.